### PR TITLE
V1.3

### DIFF
--- a/AMBuilder
+++ b/AMBuilder
@@ -7,6 +7,7 @@ projectName = 'sm-mem'
 sourceFiles = [
   'extension.cpp',
   'natives.cpp',
+  'dynlib.cpp',
 ]
 
 ###############

--- a/PackageScript
+++ b/PackageScript
@@ -30,8 +30,9 @@ def CopyFiles(src, dest, files):
 # Include files 
 CopyFiles('pawn', 'addons/sourcemod/scripting/include',
   [ 'sourcemod/scripting/include/smmem.inc',
-  'sourcemod/scripting/include/smmem_vec.inc',
-  'sourcemod/scripting/include/smmem_stocks.inc'
+  'sourcemod/scripting/include/smmem/vec.inc',
+  'sourcemod/scripting/include/smmem/stocks.inc',
+  'sourcemod/scripting/include/smmem/dynlib.inc',
   ]
 )
 

--- a/dynlib.cpp
+++ b/dynlib.cpp
@@ -1,0 +1,43 @@
+#include "extension.h"
+#include "dynlib.h"
+
+#ifdef PLATFORM_WINDOWS
+#include <libloaderapi.h>
+#endif
+
+DynLib::DynLib(const char *name)
+	: m_Name(name)
+	, m_Handle(nullptr)
+{
+#ifdef PLATFORM_WINDOWS
+	m_Handle = GetModuleHandleA(name);
+	if (m_Handle == nullptr)
+		return;
+
+	m_BaseAddress = (void *)m_Handle;
+#elif defined PLATFORM_POSIX
+	m_Handle = dlopen(name, RTLD_LAZY);
+	if (m_Handle == nullptr)
+		return;
+
+	dladdr(m_Handle, &m_Info);
+#endif
+}
+
+DynLib::~DynLib()
+{
+#if defined PLATFORM_POSIX
+	if (m_Handle != nullptr)
+		dlclose(m_Handle);
+#endif
+}
+
+void *DynLib::ResolveSymbol(const char *sym)
+{
+	return memutils->ResolveSymbol((void *)m_Handle, sym);
+}
+
+void *DynLib::FindPattern(const char *pattern, size_t len)
+{
+	return memutils->FindPattern((void *)m_Handle, pattern, len);
+}

--- a/dynlib.h
+++ b/dynlib.h
@@ -1,0 +1,29 @@
+#ifndef DYNLIB
+#define DYNLIB
+
+#include "sm_platform.h"
+#include <string>
+
+#ifdef PLATFORM_WINDOWS
+#include <libloaderapi.h>
+#include <Psapi.h>
+#endif
+
+// Would use LibrarySys but meneeds handle ptr
+struct DynLib
+{
+	std::string m_Name;
+#ifdef PLATFORM_WINDOWS
+	HMODULE m_Handle;
+	void *m_BaseAddress;
+#elif defined PLATFORM_POSIX
+	void *m_Handle;
+	Dl_info m_Info;
+#endif
+
+	DynLib(const char *name);
+	~DynLib();
+	void *ResolveSymbol(const char *sym);
+	void *FindPattern(const char *pattern, size_t len);
+};
+#endif 	// DYNLIB

--- a/extension.cpp
+++ b/extension.cpp
@@ -31,19 +31,37 @@
 
 #include "extension.h"
 #include "natives.h"
+#include "dynlib.h"
 
 SMMem g_Mem;		/**< Global singleton for extension's main interface */
+HandleType_t g_DynLib = BAD_HANDLE;
 
 bool SMMem::SDK_OnLoad(char *error, size_t maxlen, bool late)
 {
 	sharesys->RegisterLibrary(myself, "SM-Mem");
+
+	HandleError err;
+	g_DynLib = handlesys->CreateType("DynLib", this, 0, NULL, NULL, myself->GetIdentity(), &err);
+	if (g_DynLib == BAD_HANDLE)
+	{
+		snprintf(error, maxlen, "Could not create DynLib handle (err: %d)", err);
+		return false;
+	}
+
 	sharesys->AddNatives(myself, g_Natives);
+
 	return true;
 }
 
 void SMMem::SDK_OnUnload()
 {
 	
+}
+
+void SMMem::OnHandleDestroy(HandleType_t type, void *object)
+{
+	if (type == g_DynLib)
+		delete (DynLib *)object;
 }
 
 SMEXT_LINK(&g_Mem);

--- a/extension.h
+++ b/extension.h
@@ -34,7 +34,7 @@
 
 #include "smsdk_ext.h"
 
-class SMMem : public SDKExtension
+class SMMem : public SDKExtension, public IHandleTypeDispatch
 {
 public:
 	/**
@@ -51,6 +51,7 @@ public:
 	 * @brief This is called right before the extension is unloaded.
 	 */
 	virtual void SDK_OnUnload();
+	virtual void OnHandleDestroy(HandleType_t type, void *object);
 
 	/**
 	 * @brief This is called once all known extensions have been loaded.

--- a/natives.h
+++ b/natives.h
@@ -3,4 +3,7 @@
 
 #include "extension.h"
 
+extern SMMem g_Mem;
+extern HandleType_t g_DynLib;
+
 #endif 	// NATIVES_INCLUDED

--- a/pawn/sourcemod/scripting/include/smmem.inc
+++ b/pawn/sourcemod/scripting/include/smmem.inc
@@ -13,11 +13,17 @@
 native any Calloc(int num, int size);
 native any Malloc(int size);
 native any Realloc(any p, int size);
+native any ReallocF(any p, int size);
 native void Free(any p);
+native void FreeF(any p);
 native void MemMove(any dest, any src, int size);
+native void MemMoveF(any dest, any src, int size);
 native any MemCopy(any dest, any src, int size);
+native any MemCopyF(any dest, any src, int size);
 native int MemCmp(any p1, any p2, int size);
+native int MemCmpF(any p1, any p2, int size);
 native void MemSet(any p, int val, int size);
+native void MemSetF(any p, int val, int size);
 
 /**
  *	Emit a sequence of asm.
@@ -82,37 +88,56 @@ stock any realloc(any p, int size)
 {
 	return Realloc(p, size);
 }
+stock any reallocf(any p, int size)
+{
+	return ReallocF(p, size);
+}
 stock void free(any p)
 {
 	Free(p);
+}
+stock void freef(any p)
+{
+	FreeF(p);
 }
 stock void memmove(any dest, any src, int size)
 {
 	MemMove(dest, src, size);
 }
+stock void memmovef(any dest, any src, int size)
+{
+	MemMoveF(dest, src, size);
+}
 stock any memcpy(any dest, any src, int size)
 {
 	return MemCopy(dest, src, size);
+}
+stock any memcpyf(any dest, any src, int size)
+{
+	return MemCopyF(dest, src, size);
 }
 stock int memcmp(any p1, any p2, int size)
 {
 	return MemCmp(p1, p2, size);
 }
+stock int memcmpf(any p1, any p2, int size)
+{
+	return MemCmpF(p1, p2, size);
+}
 stock void memset(any p, int val, int size)
 {
 	MemSet(p, val, size);
 }
+stock void memsetf(any p, int val, int size)
+{
+	MemSetF(p, val, size);
+}
 #endif
 
-stock any Deref(any addr, NumberType numt = NumberType_Int32)
-{
-	return LoadFromAddress(view_as< Address >(addr), numt);
-}
-
-stock void WriteVal(any addr, any val, NumberType numt = NumberType_Int32)
-{
-	StoreToAddress(view_as< Address >(addr), view_as< int >(val), numt);
-}
+#include <smmem/stocks>
+#include <smmem/vec>
+#include <smmem/handle>
+#include <smmem/dynlib>
 
 public Extension __ext_smmem =
 {
@@ -144,5 +169,20 @@ public void __ext_smmem_SetNTVOptional()
 	MarkNativeAsOptional("Emit");
 	MarkNativeAsOptional("AddressOf");
 	MarkNativeAsOptional("AddressOfString");
+	MarkNativeAsOptional("StoreToAddressFast");
+	MarkNativeAsOptional("SetMemAccess");
+
+	MarkNativeAsOptional("ReallocF");
+	MarkNativeAsOptional("FreeF");
+	MarkNativeAsOptional("MemMoveF");
+	MarkNativeAsOptional("MemCopyF");
+	MarkNativeAsOptional("MemCmpF");
+	MarkNativeAsOptional("MemSetF");
+
+	MarkNativeAsOptional("DynLib.DynLib");
+	MarkNativeAsOptional("DynLib.BaseAddr.get");
+	MarkNativeAsOptional("DynLib.GetName");
+	MarkNativeAsOptional("DynLib.FindPattern");
+	MarkNativeAsOptional("DynLib.ResolveSymbol");
 }
 #endif

--- a/pawn/sourcemod/scripting/include/smmem/dynlib.inc
+++ b/pawn/sourcemod/scripting/include/smmem/dynlib.inc
@@ -1,0 +1,58 @@
+#if defined _smmem_dynlib_included
+	#endinput
+#endif
+#define _smmem_dynlib_included
+
+#include <smmem>
+
+methodmap DynLib < Handle
+{
+	/**
+	 *	Load a running dynamic library (.dll/.so)
+	 *
+	 *	@param name 			Name of the library to open.
+	 *							Exclude file extensions (.dll/.so).
+	 *							The extension adds those automatically.
+	 *
+	 *	@return 				Handle to new DynLib object. Must be freed 
+	 *							with delete/CloseHandle
+	*/
+	public native DynLib(const char[] name);
+
+	/**
+	 *	Retrieve the base address of the file in memory.
+	*/
+	property Address BaseAddr
+	{
+		public native get();
+	}
+
+	/**
+	 *	Get the name of the loaded library.
+	 *
+	 *	@param buffer 			String buffer.
+	 *	@param len 				Buffer length.
+	*/
+	public native void GetName(char[] buffer, int len);
+
+	/**
+	 *	Find a pattern of bytes in a library AKA sigscan.
+	 *
+	 *	@param pattern 			String of bytes.
+	 *	@param len 				Length of string.
+	 *
+	 *	@return 				Address of the found pattern, Address_Null
+	 * 							if not found.
+	*/
+	public native Address FindPattern(const char[] pattern, int len);
+
+	/**
+	 *	Find the address of a symbol in a library
+	 *
+	 *	@param sym 				Symbol to find, does not need to start with '@'.
+	 *
+	 *	@return 				Address of the symbol if found, Address_Null
+	 * 							otherwise.
+	*/
+	public native Address ResolveSymbol(const char[] sym);
+};

--- a/pawn/sourcemod/scripting/include/smmem/stocks.inc
+++ b/pawn/sourcemod/scripting/include/smmem/stocks.inc
@@ -14,6 +14,7 @@ stock void WriteVal(any addr, any val, NumberType numt = NumberType_Int32)
 {
 	StoreToAddress(view_as< Address >(addr), view_as< int >(val), numt);
 }
+
 stock void WriteValF(any addr, any val, NumberType numt = NumberType_Int32)
 {
 	StoreToAddressFast(view_as< Address >(addr), view_as< int >(val), numt);
@@ -56,6 +57,14 @@ stock any ArrayToPtr(any[] array, int size, NumberType numt = NumberType_Int32)
 	return p;
 }
 
+stock any ArrayToPtrF(any[] array, int size, NumberType numt = NumberType_Int32)
+{
+	int p = Malloc(size * 4);
+	for (int i = 0, mult = 0; i < size; ++i, mult += (1 << view_as< int >(numt)))
+		WriteValF(p + mult, array[i], numt);
+	return p;
+}
+
 stock void PtrToArray(any p, any[] array, int size, NumberType numt = NumberType_Int32)
 {
 	for (int i = 0, mult = 0; i < size; ++i, mult += (1 << view_as< int >(numt)))
@@ -70,8 +79,34 @@ stock any StringToPtr(const char[] str, int size)
 	return p;
 }
 
+stock any StringToPtrF(const char[] str, int size)
+{
+	int p = Malloc(size);
+	for (int i = 0; i < size; ++i)
+		WriteValF(p + i, str[i], NumberType_Int8);
+	return p;
+}
+
 stock void PtrToString(any p, char[] str, int size)
 {
 	for (int i = 0; i < size; ++i)
 		str[i] = view_as< int >(Deref(p + i, NumberType_Int8));
+}
+
+stock void WriteString(any p, const char[] str, int size = -1)
+{
+	if (size == -1)
+		size = strlen(str);
+
+	for (int i = 0; i < size; ++i)
+		WriteVal(p + i, str[i], NumberType_Int8);
+}
+
+stock void WriteStringF(any p, const char[] str, int size = -1)
+{
+	if (size == -1)
+		size = strlen(str);
+
+	for (int i = 0; i < size; ++i)
+		WriteValF(p + i, str[i], NumberType_Int8);
 }

--- a/pawn/sourcemod/scripting/include/smmem/stocks.inc
+++ b/pawn/sourcemod/scripting/include/smmem/stocks.inc
@@ -5,6 +5,20 @@
 
 #include <smmem>
 
+stock any Deref(any addr, NumberType numt = NumberType_Int32)
+{
+	return LoadFromAddress(view_as< Address >(addr), numt);
+}
+
+stock void WriteVal(any addr, any val, NumberType numt = NumberType_Int32)
+{
+	StoreToAddress(view_as< Address >(addr), view_as< int >(val), numt);
+}
+stock void WriteValF(any addr, any val, NumberType numt = NumberType_Int32)
+{
+	StoreToAddressFast(view_as< Address >(addr), view_as< int >(val), numt);
+}
+
 stock any GetEntityHandle(int ent)
 {
 	if (!IsValidEntity(ent))

--- a/pawn/sourcemod/scripting/include/smmem/vec.inc
+++ b/pawn/sourcemod/scripting/include/smmem/vec.inc
@@ -198,7 +198,7 @@ methodmap CUtlVector
 
 	public int AddToTail(any data = 0, int size = 4)
 	{
-		return this.InsertBefore(this.m_Size, size);
+		return this.InsertBefore(this.m_Size, data, size);
 	}
 
 	public int Find(any src, int size = 4)

--- a/pawn/sourcemod/scripting/memtest.sp
+++ b/pawn/sourcemod/scripting/memtest.sp
@@ -45,4 +45,14 @@ public void OnPluginStart()
 
 	free(p);
 	free(l);
+
+	DynLib lib = new DynLib("server");
+	PrintToServer("BaseAddr: %X", lib.BaseAddr);
+	char name[64]; lib.GetName(name, sizeof(name));
+	PrintToServer("Name: %s", name);
+	PrintToServer("Pattern: %X", lib.FindPattern("\x55", 1));
+	PrintToServer("Pattern-BaseAddr: %X", lib.FindPattern("\x55", 1) - lib.BaseAddr);
+	PrintToServer("ResolveSymbol: %X", lib.ResolveSymbol("?DropSoundThink@CTFAmmoPack@@QAEXXZ"));
+	PrintToServer("ResolveSymbol-BaseAddr: %X", lib.ResolveSymbol("?DropSoundThink@CTFAmmoPack@@QAEXXZ") - lib.BaseAddr);
+	delete lib;
 }

--- a/smsdk_config.h
+++ b/smsdk_config.h
@@ -40,7 +40,7 @@
 /* Basic information exposed publicly */
 #define SMEXT_CONF_NAME			"SM-Mem"
 #define SMEXT_CONF_DESCRIPTION	"Exposes raw memory for SourceMod plugins"
-#define SMEXT_CONF_VERSION		"1.2.0.5"
+#define SMEXT_CONF_VERSION		"1.3.0.6"
 #define SMEXT_CONF_AUTHOR		"Scag"
 #define SMEXT_CONF_URL			"https://github.com/Scags?tab=repositories"
 #define SMEXT_CONF_LOGTAG		"SM-MEM"
@@ -60,15 +60,15 @@
 
 /** Enable interfaces you want to use here by uncommenting lines */
 //#define SMEXT_ENABLE_FORWARDSYS
-//#define SMEXT_ENABLE_HANDLESYS
+#define SMEXT_ENABLE_HANDLESYS
 //#define SMEXT_ENABLE_PLAYERHELPERS
 //#define SMEXT_ENABLE_DBMANAGER
 //#define SMEXT_ENABLE_GAMECONF
-//#define SMEXT_ENABLE_MEMUTILS
+#define SMEXT_ENABLE_MEMUTILS
 //#define SMEXT_ENABLE_GAMEHELPERS
 //#define SMEXT_ENABLE_TIMERSYS
 //#define SMEXT_ENABLE_THREADER
-//#define SMEXT_ENABLE_LIBSYS
+#define SMEXT_ENABLE_LIBSYS
 //#define SMEXT_ENABLE_MENUS
 //#define SMEXT_ENABLE_ADTFACTORY
 //#define SMEXT_ENABLE_PLUGINSYS


### PR DESCRIPTION
Add new "fast" memory functions, ones that don't use SetMemAccess as to native speed.
Add more stocks that reflect above functions.
Add a new `DynLib` type. This is essentially a handle to a running .dll/.so and exposes natives such as `FindPattern` and `ResolveSymbol` for developers to make runtime memory management that isn't excluded to gamedata files. This in turn also exposes more libraries to be read from and written to.
Refactor include files and organize their file structure, also fix a few bugs that remain with CUtlVector.

Untested on Linux.