### PR TITLE
Fix compile errors and warnings for latest spcomp

### DIFF
--- a/pawn/sourcemod/scripting/include/smmem/vec.inc
+++ b/pawn/sourcemod/scripting/include/smmem/vec.inc
@@ -18,8 +18,6 @@ CUtlVector<Data> {
 #endif
 
 
-enum CUtlVector{}
-
 stock CUtlVector operator+(CUtlVector oper1, int oper2)
 {
 	return oper1 + view_as< CUtlVector >(oper2);
@@ -229,13 +227,6 @@ methodmap CUtlVector
 	public bool HasElement(any val, int size = 4)
 	{
 		return this.Find(val, size) >= 0;
-	}
-
-	public void Destruct(int elem, int size = 4)
-	{
-		// Okay so freeing random shit is bad, I think we can all agree on that
-		// Destruct calls the destructor which can be literally anything so do it yourself ig
-//		WriteVal(this.m_pMemory + elem * size, 0);
 	}
 
 	public void FastRemove(int elem, int size = 4)

--- a/pawn/sourcemod/scripting/include/smmem/vec.inc
+++ b/pawn/sourcemod/scripting/include/smmem/vec.inc
@@ -229,6 +229,13 @@ methodmap CUtlVector
 		return this.Find(val, size) >= 0;
 	}
 
+	public void Destruct(int elem, int size = 4)
+	{
+		// Okay so freeing random shit is bad, I think we can all agree on that
+		// Destruct calls the destructor which can be literally anything so do it yourself ig
+//		WriteVal(this.m_pMemory + elem * size, 0);
+	}
+
 	public void FastRemove(int elem, int size = 4)
 	{
 		this.Destruct(elem);

--- a/pawn/sourcemod/scripting/include/smmem/vec.inc
+++ b/pawn/sourcemod/scripting/include/smmem/vec.inc
@@ -231,6 +231,8 @@ methodmap CUtlVector
 
 	public void Destruct(int elem, int size = 4)
 	{
+		#pragma unused elem
+		#pragma unused size
 		// Okay so freeing random shit is bad, I think we can all agree on that
 		// Destruct calls the destructor which can be literally anything so do it yourself ig
 //		WriteVal(this.m_pMemory + elem * size, 0);

--- a/pawn/sourcemod/scripting/include/smmem/winnt.inc
+++ b/pawn/sourcemod/scripting/include/smmem/winnt.inc
@@ -401,25 +401,6 @@ methodmap PIMAGE_NT_HEADERS32
 #define IMAGE_DLLCHARACTERISTICS_GUARD_CF     0x4000     // Image supports Control Flow Guard.
 #define IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE     0x8000
 
-// Directory Entries
-
-#define IMAGE_DIRECTORY_ENTRY_EXPORT          0   // Export Directory
-#define IMAGE_DIRECTORY_ENTRY_IMPORT          1   // Import Directory
-#define IMAGE_DIRECTORY_ENTRY_RESOURCE        2   // Resource Directory
-#define IMAGE_DIRECTORY_ENTRY_EXCEPTION       3   // Exception Directory
-#define IMAGE_DIRECTORY_ENTRY_SECURITY        4   // Security Directory
-#define IMAGE_DIRECTORY_ENTRY_BASERELOC       5   // Base Relocation Table
-#define IMAGE_DIRECTORY_ENTRY_DEBUG           6   // Debug Directory
-//      IMAGE_DIRECTORY_ENTRY_COPYRIGHT       7   // (X86 usage)
-#define IMAGE_DIRECTORY_ENTRY_ARCHITECTURE    7   // Architecture Specific Data
-#define IMAGE_DIRECTORY_ENTRY_GLOBALPTR       8   // RVA of GP
-#define IMAGE_DIRECTORY_ENTRY_TLS             9   // TLS Directory
-#define IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG    10   // Load Configuration Directory
-#define IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT   11   // Bound Import Directory in headers
-#define IMAGE_DIRECTORY_ENTRY_IAT            12   // Import Address Table
-#define IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT   13   // Delay Load Import Descriptors
-#define IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR 14   // COM Runtime descriptor
-
 #if 0
 typedef struct _IMAGE_DOS_HEADER {      // DOS .EXE header
     WORD   e_magic;                     // Magic number


### PR DESCRIPTION
* `enum CUtlVector{}`: This is illegal syntax now and will cause `invalid function call, not a valid address` compile errors when attempting to call CUtlVector constructor
* `CUtlVector.Destruct`: Causes "unused parameter" warnings
* `IMAGE_DIRECTORY_ENTRY_` defines: Already defined further up in the file, causes redeclare warnings